### PR TITLE
Improve self-host setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 
 There are several ways to self-host Sim Studio:
 
+The project includes an example environment file at `apps/sim/.env.example`.
+Copy this file to `.env` and adjust the values to match your setup before
+starting the application.
+
 ### Option 1: Docker Environment (Recommended)
 
 ```bash
@@ -39,6 +43,9 @@ docker compose up -d --build
 or
 
 ./start_simstudio_docker.sh
+
+# Windows and cross-platform users can run the Node.js helper
+node start_simstudio_docker.js
 ```
 
 After running these commands:

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -26,3 +26,7 @@ COPY apps/sim/package.json ./apps/sim/package.json
 COPY apps/sim/lib/env.ts ./apps/sim/lib/env.ts
 
 WORKDIR /app/apps/sim
+
+# This image is used by docker-compose to run migrations.
+# Provide a default command so it can be executed standalone.
+CMD ["bun", "run", "db:push"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "simstudio",
   "packageManager": "bun@1.2.12",
+  "engines": {
+    "node": ">=18",
+    "bun": "1.2.12"
+  },
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",

--- a/packages/simstudio/README.md
+++ b/packages/simstudio/README.md
@@ -18,6 +18,26 @@ To start Sim Studio, simply run:
 simstudio
 ```
 
+### Examples
+
+- Start on a different port:
+
+```bash
+simstudio --port 4000
+```
+
+- Skip pulling the latest Docker images:
+
+```bash
+simstudio --no-pull
+```
+
+- Run without prompts using defaults:
+
+```bash
+simstudio -y
+```
+
 ### Options
 
 - `-p, --port <port>`: Specify the port to run Sim Studio on (default: 3000).

--- a/start_simstudio_docker.js
+++ b/start_simstudio_docker.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+const {spawnSync, execSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const simDir = path.join(__dirname, 'apps', 'sim');
+const envPath = path.join(simDir, '.env');
+
+function showHelp() {
+  console.log(`Usage: node start_simstudio_docker.js [--local]\n` +
+    `  --local   Use local LLM configuration (Ollama)\n`);
+}
+
+const args = process.argv.slice(2);
+if (args.includes('-h') || args.includes('--help')) {
+  showHelp();
+  process.exit(0);
+}
+const useLocal = args.includes('--local');
+
+if (!fs.existsSync(envPath)) {
+  fs.copyFileSync(path.join(simDir, '.env.example'), envPath);
+  console.log('Created .env from .env.example. Please review the file.');
+} else {
+  console.log('.env file found.');
+}
+
+function hasGpu() {
+  try {
+    execSync('nvidia-smi', {stdio: 'ignore'});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const composeArgs = ['compose'];
+if (useLocal) {
+  composeArgs.push('--profile', hasGpu() ? 'local-gpu' : 'local-cpu');
+}
+composeArgs.push('up', '--build', '-d');
+console.log(`Running: docker ${composeArgs.join(' ')}`);
+spawnSync('docker', composeArgs, {stdio: 'inherit'});
+
+console.log('Waiting for database to be ready...');
+spawnSync(process.platform === 'win32' ? 'timeout' : 'sleep', ['5'], {stdio: 'inherit'});
+
+console.log('Applying database migrations...');
+spawnSync('docker', ['compose', 'exec', 'simstudio', 'bash', '-c', 'cd apps/sim && bun run db:push'], {stdio: 'inherit'});
+
+console.log('Sim Studio is now running at http://localhost:3000');
+console.log('To view logs, run: docker compose logs -f simstudio');
+


### PR DESCRIPTION
## Summary
- document env file location and add Node.js helper command for Windows
- add examples to CLI README
- add cross-platform start script
- document default command in DB Dockerfile
- specify engines in package.json

## Testing
- `bun run test` *(fails: turbo not found)*